### PR TITLE
fix: no scroll when lightbox is open

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -18,6 +18,10 @@ body {
 	min-height: 100vh;
 }
 
+body:has(.lightbox:target) {
+	overflow: hidden;
+}
+
 @media (prefers-color-scheme: dark) {
 	html {
 		background: #222;


### PR DESCRIPTION
- don't allow scrolling while lightbox is open/in foreground